### PR TITLE
fix: weibo social accounts can not be displayed

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -72,7 +72,7 @@
           th:href="'https://weibo.com/'+${sns?.weibo}"
           th:if="${not #strings.isEmpty(sns?.weibo)}"
         >
-          <i class="iconify iconify-middle" data-icon="mdi:weibo"></i>
+          <i class="iconify iconify-middle" data-icon="bi:sina-weibo"></i>
         </a>
         <a
           class="icon"


### PR DESCRIPTION
### What this PR does?
修复微博社交账号图标无法显示的问题

Fixes #29